### PR TITLE
fix: CreditUnit制約による単位数管理の修正

### DIFF
--- a/src/contexts/course-registration/SelectCoursesStory.test.ts
+++ b/src/contexts/course-registration/SelectCoursesStory.test.ts
@@ -55,8 +55,8 @@ describe('Story 2.1: 複数履修科目選択', () => {
         expect(registration.studentId).toBe(studentId);
         expect(registration.semesterId).toBe(semesterId);
         expect(registration.selectedCourses).toHaveLength(3);
+        expect(registration.totalCredits).toBe(7); // 合計単位数
         expect(registration.actualTotalCredits).toBe(7); // 実際の累積単位数
-        expect(Number(registration.totalCredits)).toBe(7); // CreditUnit制限内での値
 
         return event;
       });

--- a/src/contexts/course-registration/application/query-handlers/GetStudentRegistrationHandler.ts
+++ b/src/contexts/course-registration/application/query-handlers/GetStudentRegistrationHandler.ts
@@ -1,6 +1,6 @@
 import * as Effect from 'effect/Effect';
 import * as Schema from '@effect/schema/Schema';
-import { StudentId, SemesterId, CreditUnit } from '../../../../shared-kernel/index.js';
+import { StudentId, SemesterId } from '../../../../shared-kernel/index.js';
 import { CourseType } from '../../domain/value-objects/index.js';
 import { EventStore } from '../../../../infrastructure/event-store/index.js';
 import { StudentRegistration } from '../../domain/aggregates/StudentRegistration.js';
@@ -83,7 +83,7 @@ export const GetStudentRegistrationHandler = {
             registration = {
               ...registration,
               selectedCourses: [...registration.selectedCourses, selectedCourse],
-              totalCredits: CreditUnit.make(Math.min(totalCreditsAccumulator + Number(courseSelection.credits), 10)) // CreditUnitの制約でおかしなことになってる件。
+              totalCredits: totalCreditsAccumulator + Number(courseSelection.credits)
             };
 
             totalCreditsAccumulator += Number(courseSelection.credits);

--- a/src/contexts/course-registration/domain/aggregates/StudentRegistration.ts
+++ b/src/contexts/course-registration/domain/aggregates/StudentRegistration.ts
@@ -53,18 +53,7 @@ export interface CourseSelection {
   readonly credits: CreditUnit;
 }
 
-/**
- * 選択科目の追加単位数を計算
- */
-const calculateAdditionalCredits = (
-  courseSelections: readonly CourseSelection[]
-): number =>
-  courseSelections.reduce(
-    (sum, selection) => sum + Number(selection.credits),
-    0
-  );
-
-/**
+ /**
  * 単位数制限をチェック
  */
 const validateCreditLimit = (
@@ -109,7 +98,7 @@ export const StudentRegistrationModule = {
   ): Effect.Effect<CoursesSelected, CreditLimitExceeded> =>
     Effect.gen(function* () {
       // 追加単位数を計算
-      const additionalCredits = calculateAdditionalCredits(courseSelections);
+      const additionalCredits = courseSelections.reduce((sum, selection) => sum + Number(selection.credits), 0);
 
       // 単位数制限をチェック
       yield* validateCreditLimit(registration.totalCredits, additionalCredits);

--- a/src/contexts/course-registration/domain/aggregates/StudentRegistration.ts
+++ b/src/contexts/course-registration/domain/aggregates/StudentRegistration.ts
@@ -108,12 +108,11 @@ export const StudentRegistrationModule = {
     courseSelections: readonly CourseSelection[]
   ): Effect.Effect<CoursesSelected, CreditLimitExceeded> =>
     Effect.gen(function* () {
-      // 現在の単位数と追加単位数を計算
-      const currentCredits = registration.totalCredits;
+      // 追加単位数を計算
       const additionalCredits = calculateAdditionalCredits(courseSelections);
 
       // 単位数制限をチェック
-      yield* validateCreditLimit(currentCredits, additionalCredits);
+      yield* validateCreditLimit(registration.totalCredits, additionalCredits);
 
       // イベントを生成
       return {

--- a/src/contexts/course-registration/domain/aggregates/StudentRegistration.ts
+++ b/src/contexts/course-registration/domain/aggregates/StudentRegistration.ts
@@ -28,7 +28,7 @@ export const StudentRegistrationSchema = Schema.Struct({
   semesterId: SemesterId.Schema.annotations({ title: "学期ID" }),
   selectedCourses: Schema.Array(SelectedCourseSchema).annotations({ title: "選択科目リスト" }),
   registrationStatus: RegistrationStatus.Schema.annotations({ title: "履修ステータス" }),
-  totalCredits: CreditUnit.Schema.annotations({ title: "合計単位数" }),
+  totalCredits: Schema.Number.annotations({ title: "合計単位数" }),
   submittedAt: Schema.optional(Schema.Date).annotations({ title: "提出日時" }),
   confirmedAt: Schema.optional(Schema.Date).annotations({ title: "確定日時" })
 });
@@ -95,7 +95,7 @@ export const StudentRegistrationModule = {
     semesterId,
     selectedCourses: [],
     registrationStatus: RegistrationStatus.Value.Draft,
-    totalCredits: CreditUnit.zero(),
+    totalCredits: 0,
     submittedAt: undefined,
     confirmedAt: undefined
   }),
@@ -109,7 +109,7 @@ export const StudentRegistrationModule = {
   ): Effect.Effect<CoursesSelected, CreditLimitExceeded> =>
     Effect.gen(function* () {
       // 現在の単位数と追加単位数を計算
-      const currentCredits = StudentRegistrationModule.currentCredits(registration);
+      const currentCredits = registration.totalCredits;
       const additionalCredits = calculateAdditionalCredits(courseSelections);
 
       // 単位数制限をチェック
@@ -127,12 +127,6 @@ export const StudentRegistrationModule = {
         timestamp: new Date()
       };
     }),
-  // 現在の履修済み単位数を計算
-  currentCredits: (registration: StudentRegistration): number =>
-    registration.selectedCourses.reduce(
-      (sum, course) => sum + Number(course.credits),
-      0
-    )
 } as const;
 
 export { StudentRegistrationModule as StudentRegistration, SelectedCourseModule as SelectedCourse };


### PR DESCRIPTION
## Summary
- CreditUnit制約によるtotalCreditsの型不整合を修正
- StudentRegistrationのtotalCreditsをnumber型に変更
- calculateAdditionalCreditsヘルパー関数をインライン化
- テストの期待値を修正してCreditUnit制約の問題を解決

## Test plan
- [x] 既存テストの実行確認
- [x] 単位数計算ロジックの整合性確認
- [x] CreditUnit制約による不整合の解消確認

🤖 Generated with [Claude Code](https://claude.ai/code)